### PR TITLE
mapをスクロールで操作できるようにする修正

### DIFF
--- a/Fenrir/Model/LocationManager.swift
+++ b/Fenrir/Model/LocationManager.swift
@@ -16,12 +16,20 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
         super.init()
         self.locationManager.delegate = self
         self.locationManager.requestWhenInUseAuthorization()
-        self.locationManager.startUpdatingLocation()
+        self.requestCurrentLocation()
     }
+    
+    func requestCurrentLocation() {
+            self.locationManager.requestLocation()
+        }
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let location = locations.last {
             self.location = location
         }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("位置情報の取得に失敗しました: \(error)")
     }
 }

--- a/Fenrir/View/MapView.swift
+++ b/Fenrir/View/MapView.swift
@@ -22,7 +22,7 @@ struct MapView: View {
                 if let mapPosition = mapViewModel.location {
                     Map(position: .constant(mapPosition))
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .overlay {
+                        .overlay(alignment: .bottom) {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 LazyHStack(alignment: .bottom) {
                                     ForEach(mapViewModel.shops) { shop in
@@ -34,6 +34,7 @@ struct MapView: View {
                                     }
                                 }
                             }
+                            .frame(height: 150)
                         }
                 } else {
                     ProgressView("現在地を取得中...")

--- a/Fenrir/View/MapView.swift
+++ b/Fenrir/View/MapView.swift
@@ -40,6 +40,20 @@ struct MapView: View {
                     ProgressView("現在地を取得中...")
                 }
             } // VStack
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        mapViewModel.updateLocation()
+                    } label: {
+                        HStack(spacing: 0) {
+                            Image(systemName: "mappin.and.ellipse")
+                            
+                            Text("更新")
+                        }
+                    }
+
+                }
+            }
         } // NavigationStack
     }
 }

--- a/Fenrir/ViewModel/MapViewModel.swift
+++ b/Fenrir/ViewModel/MapViewModel.swift
@@ -47,16 +47,24 @@ class MapViewModel: ObservableObject {
         }
     }
     
+    func updateLocation() {
+        locationManager.requestCurrentLocation()
+    }
+    
     private func setUpSubscriber() {
         self.cancellable = locationManager.$location
             .compactMap { $0 } // nilを除外
-            .map { location in
-                MapCameraPosition.region(MKCoordinateRegion(
+            .sink { [weak self] location in
+                guard let self = self else { return }
+                self.location = .region(MKCoordinateRegion(
                     center: CLLocationCoordinate2D(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude),
                     latitudinalMeters: 100.0,
                     longitudinalMeters: 100.0
                 ))
+                
+                Task {
+                    await self.loadShop(range: 2)
+                }
             }
-            .assign(to: \.location, on: self)
     }
 }


### PR DESCRIPTION
## 概要
mapをスクロールで操作できるようにする修正

## 問題点
- 店舗一覧情報を表示するScrollViewのサイズがmapの表示領域と被っていて操作できなかった
- 位置情報が自動で更新されるため、mapを操作していても元の位置に戻されてしまう

## 変更
- ScrollViewを適切なサイズに
- 自動更新をやめ、ボタンによる手動更新に